### PR TITLE
ScalaBuff version bump.

### DIFF
--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -17,7 +17,7 @@ object ScalaBuffPlugin extends Plugin {
   lazy val scalabuffSettings = Seq[Project.Setting[_]](
     scalabuffArgs := Seq(),
     scalabuffMain := "net.sandrogrzicic.scalabuff.compiler.ScalaBuff",
-    scalabuffVersion := "1.1.1",
+    scalabuffVersion := "1.1.2",
     libraryDependencies <++= (scalabuffVersion in ScalaBuff)(version => 
       Seq(
         "net.sandrogrzicic" %% "scalabuff-compiler" % version % ScalaBuff.name,


### PR DESCRIPTION
I've updated ScalaBuff to 1.1.2. I guess in the future some sort of a more robust mechanism would be nice.
