### PR TITLE
Put sourceManaged files in a subdirectory found by sbt-idea

### DIFF
--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -56,7 +56,7 @@ object ScalaBuffPlugin extends Plugin {
   ): Seq[File] = {
     val input = source / "protobuf"
     if (input.exists) {
-      val output = sourceManaged / "scala"
+      val output = sourceManaged / "main" / "scalabuff"
       val cached = FileFunction.cached(cache / "scalabuff", FilesInfo.lastModified, FilesInfo.exists) {
         (in: Set[File]) => {
           IO.delete(output)


### PR DESCRIPTION
According to this thread "https://github.com/mpeltonen/sbt-idea/issues/209", generated files should be in a "main/pluginName" subdirectory of sourceManaged. Without this changes, sbt-idea will not add the generated files to the IntelliJ project.
