### PR TITLE
Move generated source into "main" rather than "scala"

### DIFF
--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -56,7 +56,7 @@ object ScalaBuffPlugin extends Plugin {
   ): Seq[File] = {
     val input = source / "protobuf"
     if (input.exists) {
-      val output = sourceManaged / "scala"
+      val output = sourceManaged / "main"
       val cached = FileFunction.cached(cache / "scalabuff", FilesInfo.lastModified, FilesInfo.exists) {
         (in: Set[File]) => {
           IO.delete(output)


### PR DESCRIPTION
This seems to match the convention used by other plugins such as scalate.  I'm not sure if you want this change but it puts the files from scalabuff in the same tree as various other plugins...
