### PR TITLE
Add cross sbt build support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ sbtPlugin := true
 
 name := "sbt-scalabuff"
 
-version := "1.3.6"
+version := "1.3.7"
 
 organization := "com.github.sbt"
 
-scalaVersion        := "2.10.3"
+crossBuildingSettings
 
-crossScalaVersions  := Seq("2.9.2", "2.10.3")
+CrossBuilding.crossSbtVersions := Seq("0.12", "0.13")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.1")


### PR DESCRIPTION
This patch adds support for building cross sbt variants of the sbt-scalabuff plugin, through use of [sbt-cross-building](https://github.com/jrudolph/sbt-cross-building) plugin.

With this patch applied one can e.g. from sbt console issue _**^ publish-local**_ command and have two sets of sbt-scalabuff plugin artifacts published in local ivy repository, one for scala 2.9.2 and sbt 0.12, and second one for scala 2.10 and sbt 0.13.
