### PR TITLE
Extensions for latest ScalaBuff version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ sbtPlugin := true
 
 name := "sbt-scalabuff"
 
-version := "0.3_1.3.7-SNAPSHOT"
+version := "0.3.1_1.3.7-SNAPSHOT"
 
 organization := "com.github.sbt"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ sbtPlugin := true
 
 name := "sbt-scalabuff"
 
-version := "0.3_1.3.6-SNAPSHOT"
+version := "0.3_1.3.7-SNAPSHOT"
 
 organization := "com.github.sbt"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ sbtPlugin := true
 
 name := "sbt-scalabuff"
 
-version := "0.3.1_1.3.7-SNAPSHOT"
+version := "0.3.1_1.3.8"
 
 organization := "com.github.sbt"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ sbtPlugin := true
 
 name := "sbt-scalabuff"
 
-version := "0.3-SNAPSHOT"
+version := "0.3_1.3.6-SNAPSHOT"
 
 organization := "com.github.sbt"
 
-scalaVersion        := "2.10.0"
+scalaVersion        := "2.10.2"
 
-crossScalaVersions  := Seq("2.9.2", "2.10.0")
+crossScalaVersions  := Seq("2.9.2", "2.10.0", "2.10.2")

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ sbtPlugin := true
 
 name := "sbt-scalabuff"
 
-version := "0.3.1_1.3.8"
+version := "0.3.1_1.3.9"
 
 organization := "com.github.sbt"
 
-scalaVersion        := "2.10.2"
+scalaVersion        := "2.10.4"
 
-crossScalaVersions  := Seq("2.9.2", "2.10.0", "2.10.2")
+crossScalaVersions  := Seq("2.9.2", "2.10.0", "2.10.4")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.0

--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -17,7 +17,7 @@ object ScalaBuffPlugin extends Plugin {
   lazy val scalabuffSettings = Seq[Project.Setting[_]](
     scalabuffArgs := Seq(),
     scalabuffMain := "net.sandrogrzicic.scalabuff.compiler.ScalaBuff",
-    scalabuffVersion := "1.1.2",
+    scalabuffVersion := "1.3.6",
     libraryDependencies <++= (scalabuffVersion in ScalaBuff)(version => 
       Seq(
         "net.sandrogrzicic" %% "scalabuff-compiler" % version % ScalaBuff.name,

--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -56,7 +56,7 @@ object ScalaBuffPlugin extends Plugin {
   ): Seq[File] = {
     val input = source / "protobuf"
     if (input.exists) {
-      val output = sourceManaged / "scala"
+      val output = sourceManaged
       val cached = FileFunction.cached(cache / "scalabuff", FilesInfo.lastModified, FilesInfo.exists) {
         (in: Set[File]) => {
           IO.delete(output)

--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -21,7 +21,10 @@ object ScalaBuffPlugin extends Plugin {
     libraryDependencies <++= (scalabuffVersion in ScalaBuff)(version => 
       Seq(
         "net.sandrogrzicic" %% "scalabuff-compiler" % version % ScalaBuff.name,
-        "net.sandrogrzicic" %% "scalabuff-runtime" % version
+        "net.sandrogrzicic" %% "scalabuff-runtime" % version excludeAll(
+		  ExclusionRule(organization = "com.google.protobuf")
+		),
+		"com.google.protobuf" %% "protobuf-java" % "2.4.1"
       )
     ),
     sourceDirectory in ScalaBuff <<= (sourceDirectory in Compile),

--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -17,14 +17,14 @@ object ScalaBuffPlugin extends Plugin {
   lazy val scalabuffSettings = Seq[Project.Setting[_]](
     scalabuffArgs := Seq(),
     scalabuffMain := "net.sandrogrzicic.scalabuff.compiler.ScalaBuff",
-    scalabuffVersion := "1.3.7-SNAPSHOT",
+    scalabuffVersion := "1.3.8",
     libraryDependencies <++= (scalabuffVersion in ScalaBuff)(version => 
       Seq(
         "net.sandrogrzicic" %% "scalabuff-compiler" % version % ScalaBuff.name,
         "net.sandrogrzicic" %% "scalabuff-runtime" % version excludeAll(
 		  ExclusionRule(organization = "com.google.protobuf")
 		),
-		"com.google.protobuf" %% "protobuf-java" % "2.4.1"
+		"com.google.protobuf" % "protobuf-java" % "2.5.0"
       )
     ),
     sourceDirectory in ScalaBuff <<= (sourceDirectory in Compile),

--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -17,7 +17,7 @@ object ScalaBuffPlugin extends Plugin {
   lazy val scalabuffSettings = Seq[Project.Setting[_]](
     scalabuffArgs := Seq(),
     scalabuffMain := "net.sandrogrzicic.scalabuff.compiler.ScalaBuff",
-    scalabuffVersion := "1.3.8",
+    scalabuffVersion := "1.3.9",
     libraryDependencies <++= (scalabuffVersion in ScalaBuff)(version => 
       Seq(
         "net.sandrogrzicic" %% "scalabuff-compiler" % version % ScalaBuff.name,

--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -17,7 +17,7 @@ object ScalaBuffPlugin extends Plugin {
   lazy val scalabuffSettings = Seq[Project.Setting[_]](
     scalabuffArgs := Seq(),
     scalabuffMain := "net.sandrogrzicic.scalabuff.compiler.ScalaBuff",
-    scalabuffVersion := "1.3.6",
+    scalabuffVersion := "1.3.7-SNAPSHOT",
     libraryDependencies <++= (scalabuffVersion in ScalaBuff)(version => 
       Seq(
         "net.sandrogrzicic" %% "scalabuff-compiler" % version % ScalaBuff.name,
@@ -65,8 +65,9 @@ object ScalaBuffPlugin extends Plugin {
             javaHome,
             List(
               "-cp", classpath.map(_.data).mkString(File.pathSeparator), mainClass,
+              "--proto_path=" + input.toString, // processing single .proto files conflicts with protobuf import statements -> rather re-process all .protos if any has changed
               "--scala_out=" + output.toString
-            ) ++ args.toSeq ++ in.toSeq.map(_.toString),
+            ),
             streams.log
           )
           (output ** ("*.scala")).get.toSet

--- a/src/main/scala/ScalaBuffPlugin.scala
+++ b/src/main/scala/ScalaBuffPlugin.scala
@@ -70,7 +70,7 @@ object ScalaBuffPlugin extends Plugin {
               "-cp", classpath.map(_.data).mkString(File.pathSeparator), mainClass,
               "--proto_path=" + input.toString, // processing single .proto files conflicts with protobuf import statements -> rather re-process all .protos if any has changed
               "--scala_out=" + output.toString
-            ),
+            ) ++ args,                          // forward command line args to ScalaBuff - this is required for supporting Scala 2.11 builds
             streams.log
           )
           (output ** ("*.scala")).get.toSet


### PR DESCRIPTION
Hi,

this pull request contains a variety of extensions for compatibility with the latest ScalaBuff version.

(1) Upgraded default ScalaBuff version to 1.3.9.
Currently, only 1.3.8 is out, but that version seems ambigous (i.e. changes were made to 1.3.8 without version bump -> pull request to create ScalaBuff 1.3.9 is pending)

(2) upgrade to Protobuf 2.5.0 (in acc. with ScalaBuff, Akka, and most other libs)

(3) changed output folder to plain source-managed (better IDE integration)

(4) changed input of protos - instead of processing individual protos, let ScalaBuff process entire folder via --proto-path param (includes between protos do not work otherwise)

cheers,
-Tom
